### PR TITLE
added Sparkfun Pro Micro to id filter

### DIFF
--- a/apps/figma/ui.html
+++ b/apps/figma/ui.html
@@ -325,7 +325,7 @@
 			if (!gamepad) return false;
 			if (!gamepad.id) return false;
 			if (!gamepad.axes) return false;
-			if (gamepad.axes.length !== 6) return false;
+			//if (gamepad.axes.length !== 6) return false;
 
 			const gamepadName = gamepad.id.toLowerCase();
 
@@ -336,7 +336,9 @@
 				gamepadName.indexOf("spacenavigator") > -1 ||
 				gamepadName.indexOf("space navigator") > -1 ||
 				gamepadName.indexOf("spacemouse") > -1 ||
-				gamepadName.indexOf("space mouse") > -1;
+				gamepadName.indexOf("space mouse") > -1 ||
+				gamepadName.indexOf("vendor: 1b4f") > -1 ||
+				gamepadName.indexOf("vendor: SparkFun Pro Micro") > -1;
 
 			return isIdRecognized;
 		}


### PR DESCRIPTION
Hi! I'm working on an [Arduino-compatible open-source space mouse](https://github.com/gocivici/trinteract). I added the id codes for the Arduino to the id filter to make this tool compatible with DIY devices. I also commented the `gamepad.axes.length !== 6 ` to make room for devices that have more or less then 6 axes.